### PR TITLE
Fix wrong week in stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "planntt",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "author": "Stijn Heymans <stijn.heymans@gmail.com>",
   "description": "A Simple ToDo Application",
   "homepage": "http://planntt.com",

--- a/src/renderer/components/Stats.vue
+++ b/src/renderer/components/Stats.vue
@@ -181,7 +181,7 @@ export default {
                 if (momentFormat === 'YYYY-WW') {
                   const weekNumber = val.substring(val.length - 2, val.length)
                   const year = val.substr(0, 4)
-                  const mondayOfWeek = this.$moment().day('Monday').week(weekNumber).year(year)
+                  const mondayOfWeek = this.$moment().day('Monday').isoWeek(weekNumber).year(year)
                   return mondayOfWeek.format('YYYY-MM-DD')
                 }
                 return val
@@ -305,7 +305,7 @@ export default {
                 if (momentFormat === 'YYYY-WW') {
                   const weekNumber = val.substring(val.length - 2, val.length)
                   const year = val.substr(0, 4)
-                  const mondayOfWeek = this.$moment().day('Monday').week(weekNumber).year(year)
+                  const mondayOfWeek = this.$moment().day('Monday').isoWeek(weekNumber).year(year)
                   return mondayOfWeek.format('YYYY-MM-DD')
                 }
                 return val
@@ -343,7 +343,7 @@ export default {
                   } else if (momentFormat === 'YYYY-WW') {
                     const weekNumber = datePoint.substring(datePoint.length - 2, datePoint.length)
                     const year = datePoint.substr(0, 4)
-                    const mondayOfWeek = this.$moment().day('Monday').week(weekNumber).year(year)
+                    const mondayOfWeek = this.$moment().day('Monday').isoWeek(weekNumber).year(year)
                     const day = mondayOfWeek.format('YYYY-MM-DD')
                     if (durationDoneAndCreated) {
                       tooltipContent += `${durationPoint} in week of ${day}`


### PR DESCRIPTION
Weeks in the US have Sunday [as the first
day](https://momentjs.com/docs/#/get-set/week/). I'm picking Monday as
start of the week corresponding to most US work weeks.

This fixes #4